### PR TITLE
empty array interpreted as 'auto' option for downsample_time_by and downsample_space_by

### DIFF
--- a/solvers/extractor.m
+++ b/solvers/extractor.m
@@ -121,7 +121,7 @@ if ~do_auto_partition
 else
     % Account for downsampling
     dss = config.downsample_space_by;
-    if strcmp(dss, 'auto')
+    if strcmp(dss, 'auto') || isempty(dss)
         dss = max(round(config.avg_cell_radius / ...
             config.min_radius_after_downsampling), 1);
     end

--- a/solvers/run_extract.m
+++ b/solvers/run_extract.m
@@ -36,7 +36,7 @@ config.avg_event_tau = tau;
 
 % Space downsampling
 dss = config.downsample_space_by;
-if strcmp(dss, 'auto')
+if strcmp(dss, 'auto') || ismepty(dss)
     dss = max(round(config.avg_cell_radius ...
         / config.min_radius_after_downsampling), 1);
 end
@@ -58,7 +58,7 @@ max_image = max(M, [], 3);
 
 % Time downsampling
 dst = config.downsample_time_by;
-if strcmp(dst, 'auto')
+if strcmp(dst, 'auto') || isempty(dst)
     dst = max(round(tau / config.min_tau_after_downsampling), 1);
 end
 config.downsample_time_by = dst;


### PR DESCRIPTION
fixes #14 

In saving configuration parameters to an HDF5 file (such as NWB file), each parameter must take a data type. downsample_time_by and downsample_space_by can take on string (e.g. 'auto') or numeric values. In order to save these parameters to file and later reuse them, it would be ideal if the same operations that were triggered by the 'auto' string input, would also be triggered by an empty array.

This PR implements this