### PR TITLE
allows extract to work in a reduce MATLAB environment without some req toolboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.h5
 *.hdf5
 .*
+extract.sublime-project
+extract.sublime-workspace

--- a/EXTRACT/main_functions/helper_functions/find_conncomp.m
+++ b/EXTRACT/main_functions/helper_functions/find_conncomp.m
@@ -20,7 +20,17 @@ function [cc, A] = find_conncomp(X, threshold, A2)
     if exist('A2', 'var')
         A = A .* A2;
     end
-    [s, memberships] = graphconncomp(sparse(A));
+
+
+    if license('test','bioinformatics_toolbox') == 0
+        % no toolbox, use workaround
+        [s, memberships] = conncomp(sparse(A));
+
+    else
+        [s, memberships] = graphconncomp(sparse(A));
+    end
+
+    
     cc = [];
     acc=0;
     for k = 1:s

--- a/EXTRACT/toolbox_alternatives/conncomp.m
+++ b/EXTRACT/toolbox_alternatives/conncomp.m
@@ -1,4 +1,4 @@
-function [S,C] = graphconncomp(G)
+function [S,C] = conncomp(G)
 % CONNCOMP Drop in replacement for graphconncomp.m from the bioinformatics
 % toobox. G is an n by n adjacency matrix, then this identifies the S
 % connected components C. This is also an order of magnitude faster.

--- a/EXTRACT/toolbox_alternatives/graphconncomp.license
+++ b/EXTRACT/toolbox_alternatives/graphconncomp.license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Cheng-Kang Ted Chao, Karan Singh, Yotam Gingold
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/EXTRACT/toolbox_alternatives/graphconncomp.m
+++ b/EXTRACT/toolbox_alternatives/graphconncomp.m
@@ -1,0 +1,20 @@
+function [S,C] = graphconncomp(G)
+% CONNCOMP Drop in replacement for graphconncomp.m from the bioinformatics
+% toobox. G is an n by n adjacency matrix, then this identifies the S
+% connected components C. This is also an order of magnitude faster.
+%
+% [S,C] = conncomp(G)
+%
+% Inputs:
+%   G  n by n adjacency matrix
+% Outputs:
+%   S  scalar number of connected components
+%   C  
+
+
+% from http://www.alecjacobson.com/weblog/?tag=graphconncomp
+
+[p,q,r] = dmperm(G+speye(size(G)));
+S = numel(r)-1;
+C = cumsum(full(sparse(1,r(1:end-1),1,1,size(G,1))));
+C(p) = C;


### PR DESCRIPTION
I have MATLAB with only these toolboxes:

```
-----------------------------------------------------------------------------------------------------
MATLAB                                                Version 9.7         (R2019b)
Curve Fitting Toolbox                                 Version 3.5.10      (R2019b)
Image Processing Toolbox                              Version 11.0        (R2019b)
Optimization Toolbox                                  Version 8.4         (R2019b)
Parallel Computing Toolbox                            Version 7.1         (R2019b)
Signal Processing Toolbox                             Version 8.3         (R2019b)
Statistics and Machine Learning Toolbox               Version 11.6        (R2019b)
```

I was able to get EXTRACT working here by working around some functions in the bioinformatics toolbox. 

This PR will use the workaround if the toolbox is missing, but will behave normally (use the built-in) if the toolbox is present. 